### PR TITLE
Fix: mapcell에 핀이 두 개 뜨는 오류 해결

### DIFF
--- a/Weather-Group3/Screens/Map/MapCell.swift
+++ b/Weather-Group3/Screens/Map/MapCell.swift
@@ -28,7 +28,6 @@ class MapCell: UICollectionViewCell {
         super.init(frame: frame)
         setup()
         getCurrentLocation()
-        showLocation(latitude: currentLatitude, longitude: currentLongitude, pinTintColor: pinTintColor, annotationText: annotationText, systemImageName: systemImageName)
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
<img width="255" alt="Screenshot 2023-10-05 at 11 03 59 PM" src="https://github.com/Kenbbk/Weather-app/assets/139095139/c1754335-d34d-44ff-a05a-f160b9e6076a">
핀을 만들 수 있는 함수가 두 번 호출되는 것을 발견해서 삭제하였습니다!